### PR TITLE
feat: picker reorder buttons

### DIFF
--- a/app/src/components/ActionButton.vue
+++ b/app/src/components/ActionButton.vue
@@ -6,32 +6,35 @@ interface Props {
   text: string
   icon?: string
   color?: 'blue' | 'green' | 'red'
+  disabled?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   icon: '',
   color: 'blue',
+  disabled: false,
 })
 
 const emit = defineEmits(['click'])
 
 const colorMap = {
-  blue: 'bg-blue-800 text-white hover:bg-blue-600 focus:ring-blue-500',
-  green: 'bg-green-800 text-white hover:bg-green-600 focus:ring-green-500',
-  red: 'bg-red-800 text-white hover:bg-red-700 focus:ring-red-500',
+  blue: 'bg-blue-800 text-white enabled:hover:bg-blue-600 focus:ring-blue-500',
+  green: 'bg-green-800 text-white enabled:hover:bg-green-600 focus:ring-green-500',
+  red: 'bg-red-800 text-white enabled:hover:bg-red-700 focus:ring-red-500',
 }
 
 const buttonClasses = computed(() => {
   const baseClasses =
     'p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-opacity-50 flex items-center justify-center gap-2'
   const colorClasses = colorMap[props.color]
-  return `${baseClasses} ${colorClasses}`
+  const opacityClasses = props.disabled ? 'opacity-50' : ''
+  return `${baseClasses} ${colorClasses} ${opacityClasses}`
 })
 </script>
 
 <template>
-  <button :class="buttonClasses" @click="emit('click')">
-    <Icon v-if="icon" :icon="icon" height="24" />
-    {{ text }}
+  <button :class="buttonClasses" @click="emit('click')" :disabled="props.disabled">
+    <Icon v-if="props.icon" :icon="props.icon" height="24" />
+    {{ props.text }}
   </button>
 </template>

--- a/app/src/components/MenuModal.vue
+++ b/app/src/components/MenuModal.vue
@@ -6,33 +6,12 @@ const props = defineProps({
     type: String,
     default: 'Menu',
   },
-  draggable: {
-    type: Boolean,
-    default: false,
-  },
 })
 
 const emit = defineEmits(['close'])
 
 function closeModal() {
   emit('close')
-}
-
-// Drag and drop handlers to be passed to the slot
-function dragStart(event: DragEvent, index: number) {
-  event.dataTransfer?.setData('text/plain', index.toString())
-  event.dataTransfer!.effectAllowed = 'move'
-}
-
-function dragOver(event: DragEvent, index: number) {
-  event.preventDefault()
-  event.dataTransfer!.dropEffect = 'move'
-}
-
-function drop(event: DragEvent, index: number) {
-  event.preventDefault()
-  const draggedIndex = parseInt(event.dataTransfer!.getData('text/plain'))
-  emit('drop', { draggedIndex, targetIndex: index })
 }
 </script>
 
@@ -43,11 +22,8 @@ function drop(event: DragEvent, index: number) {
   >
     <div class="bg-slate-800 p-5 rounded-lg relative min-w-[250px] shadow-lg">
       <h1 class="text-xl font-bold mb-4 text-center">{{ props.title }}</h1>
-      <div class="flex flex-col gap-2">
-        <slot :dragStart="dragStart" :dragOver="dragOver" :drop="drop"></slot>
-      </div>
-      <div v-if="$slots.footer" class="mt-4 pt-4 border-t border-slate-700">
-        <slot name="footer"></slot>
+      <div class="flex flex-col gap-2" @click="closeModal">
+        <slot></slot>
       </div>
     </div>
   </div>

--- a/app/src/components/MenuModal.vue
+++ b/app/src/components/MenuModal.vue
@@ -6,12 +6,33 @@ const props = defineProps({
     type: String,
     default: 'Menu',
   },
+  draggable: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const emit = defineEmits(['close'])
 
 function closeModal() {
   emit('close')
+}
+
+// Drag and drop handlers to be passed to the slot
+function dragStart(event: DragEvent, index: number) {
+  event.dataTransfer?.setData('text/plain', index.toString())
+  event.dataTransfer!.effectAllowed = 'move'
+}
+
+function dragOver(event: DragEvent, index: number) {
+  event.preventDefault()
+  event.dataTransfer!.dropEffect = 'move'
+}
+
+function drop(event: DragEvent, index: number) {
+  event.preventDefault()
+  const draggedIndex = parseInt(event.dataTransfer!.getData('text/plain'))
+  emit('drop', { draggedIndex, targetIndex: index })
 }
 </script>
 
@@ -22,8 +43,11 @@ function closeModal() {
   >
     <div class="bg-slate-800 p-5 rounded-lg relative min-w-[250px] shadow-lg">
       <h1 class="text-xl font-bold mb-4 text-center">{{ props.title }}</h1>
-      <div class="flex flex-col gap-2" @click="closeModal">
-        <slot></slot>
+      <div class="flex flex-col gap-2">
+        <slot :dragStart="dragStart" :dragOver="dragOver" :drop="drop"></slot>
+      </div>
+      <div v-if="$slots.footer" class="mt-4 pt-4 border-t border-slate-700">
+        <slot name="footer"></slot>
       </div>
     </div>
   </div>

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -51,7 +51,7 @@ export const savePickers = async (pickers: Picker[]) => {
   pickers.sort((a, b) => a.order - b.order)
   const pickersWithOrder = pickers.map((picker, index) => ({
     ...picker,
-    order: index + 1,
+    order: index,
   }))
   const { error } = await supabase.from('picker').upsert(pickersWithOrder)
   if (error) {

--- a/app/src/views/ManagePickersView.vue
+++ b/app/src/views/ManagePickersView.vue
@@ -46,6 +46,10 @@ async function handleAddPicker() {
   ]
 }
 
+async function handleReorderPickers() {
+  // AI!: open a MenuModal and allow the user to drag-and-drop reorder the pickers. Only show the picker names in the dialog
+}
+
 async function handleSavePickers() {
   try {
     await savePickers(pickers.value)
@@ -80,6 +84,12 @@ async function handleDeletePicker(pickerUuid: string) {
           @click="handleAddPicker"
         />
         <ActionButton
+          text="Reorder"
+          icon="system-uicons:list-numbered"
+          color="blue"
+          @click="handleReorderPickers"
+        />
+        <ActionButton
           text="Save"
           icon="system-uicons:check"
           color="green"
@@ -108,15 +118,6 @@ async function handleDeletePicker(pickerUuid: string) {
             :id="`phone-${picker.uuid}`"
             type="text"
             v-model="picker.phoneNumber"
-            class="bg-slate-700 p-2 rounded-md border border-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-        </div>
-        <div class="flex flex-col gap-1">
-          <label :for="`order-${picker.uuid}`" class="text-sm text-slate-300">Order</label>
-          <input
-            :id="`order-${picker.uuid}`"
-            type="number"
-            v-model="picker.order"
             class="bg-slate-700 p-2 rounded-md border border-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>

--- a/app/src/views/ManagePickersView.vue
+++ b/app/src/views/ManagePickersView.vue
@@ -61,6 +61,22 @@ async function handleSavePickers() {
   }
 }
 
+function handleMovePicker(picker: Picker, delta: -1 | 1) {
+  const oldOrder = picker.order
+  const newOrder = picker.order + delta
+  pickers.value = pickers.value.map((p) => {
+    if (p.order == newOrder) {
+      // Move the picker being switched with
+      return { ...p, order: oldOrder }
+    } else if (p.uuid == picker.uuid) {
+      // Move the actual picker
+      return { ...p, order: newOrder }
+    } else {
+      return p
+    }
+  })
+}
+
 async function handleDeletePicker(pickerUuid: string) {
   if (confirm('Are you sure you want to delete this picker?')) {
     pickers.value = pickers.value.map((p) =>
@@ -84,12 +100,6 @@ async function handleDeletePicker(pickerUuid: string) {
           @click="handleAddPicker"
         />
         <ActionButton
-          text="Reorder"
-          icon="system-uicons:list-numbered"
-          color="blue"
-          @click="handleReorderPickers"
-        />
-        <ActionButton
           text="Save"
           icon="system-uicons:check"
           color="green"
@@ -99,7 +109,7 @@ async function handleDeletePicker(pickerUuid: string) {
     </div>
     <ul>
       <li
-        v-for="picker in displayPickers"
+        v-for="(picker, index) in displayPickers"
         :key="picker.uuid"
         class="bg-slate-800 p-4 rounded-lg mb-2 flex flex-col gap-2"
       >
@@ -121,13 +131,29 @@ async function handleDeletePicker(pickerUuid: string) {
             class="bg-slate-700 p-2 rounded-md border border-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
-        <ActionButton
-          text="Delete"
-          icon="system-uicons:trash"
-          color="red"
-          class="max-w-32"
-          @click="handleDeletePicker(picker.uuid)"
-        />
+        <div class="flex flex-row gap-1">
+          <span>{{ picker.order }}, {{ displayPickers.length }}</span>
+          <ActionButton
+            text="Down"
+            icon="system-uicons:chevron-down"
+            color="blue"
+            :disabled="index == displayPickers.length - 1"
+            @click="handleMovePicker(picker, 1)"
+          />
+          <ActionButton
+            text="Up"
+            icon="system-uicons:chevron-up"
+            color="blue"
+            :disabled="index == 0"
+            @click="handleMovePicker(picker, -1)"
+          />
+          <ActionButton
+            text="Delete"
+            icon="system-uicons:trash"
+            color="red"
+            @click="handleDeletePicker(picker.uuid)"
+          />
+        </div>
       </li>
     </ul>
   </div>

--- a/app/src/views/ManagePickersView.vue
+++ b/app/src/views/ManagePickersView.vue
@@ -62,15 +62,22 @@ async function handleSavePickers() {
 }
 
 function handleMovePicker(picker: Picker, delta: -1 | 1) {
-  const oldOrder = picker.order
-  const newOrder = picker.order + delta
+  const currentIndex = displayPickers.value.findIndex(p => p.uuid === picker.uuid)
+  const targetIndex = currentIndex + delta
+
+  if (targetIndex < 0 || targetIndex >= displayPickers.value.length) {
+    return // Invalid move
+  }
+
+  const targetPicker = displayPickers.value[targetIndex]
+  const currentOrder = picker.order
+  const targetOrder = targetPicker.order
+
   pickers.value = pickers.value.map((p) => {
-    if (p.order == newOrder) {
-      // Move the picker being switched with
-      return { ...p, order: oldOrder }
-    } else if (p.uuid == picker.uuid) {
-      // Move the actual picker
-      return { ...p, order: newOrder }
+    if (p.uuid === picker.uuid) {
+      return { ...p, order: targetOrder }
+    } else if (p.uuid === targetPicker.uuid) {
+      return { ...p, order: currentOrder }
     } else {
       return p
     }

--- a/app/src/views/ManagePickersView.vue
+++ b/app/src/views/ManagePickersView.vue
@@ -4,13 +4,10 @@ import ActionButton from '@/components/ActionButton.vue'
 import { getOrganization, getPickers, savePickers } from '@/lib/utils'
 import { Icon } from '@iconify/vue'
 import { type Picker } from '@/models/picker'
-import MenuModal from '@/components/MenuModal.vue'
 
 const pickers = ref<Picker[]>([])
 const isLoading = ref(true)
 const error = ref(null)
-const showReorderModal = ref(false)
-let draggedItemIndex = -1
 
 // Sort by order and only include non-deleted
 const displayPickers = computed(() => {
@@ -50,20 +47,7 @@ async function handleAddPicker() {
 }
 
 async function handleReorderPickers() {
-  showReorderModal.value = true
-}
-
-function closeReorderModal() {
-  showReorderModal.value = false
-}
-
-async function saveReorder(orderedPickers: Picker[]) {
-  pickers.value = orderedPickers.map((p, index) => ({
-    ...p,
-    order: index + 1,
-  }))
-  await handleSavePickers()
-  closeReorderModal()
+  // AI!: open a MenuModal and allow the user to drag-and-drop reorder the pickers. Only show the picker names in the dialog
 }
 
 async function handleSavePickers() {
@@ -84,31 +68,6 @@ async function handleDeletePicker(pickerUuid: string) {
     )
   }
 }
-
-function onDragStart(event: DragEvent, index: number) {
-  draggedItemIndex = index
-  event.dataTransfer?.effectAllowed = 'move'
-}
-
-function onDragOver(event: DragEvent, index: number) {
-  event.preventDefault()
-  event.dataTransfer!.dropEffect = 'move'
-  if (index !== draggedItemIndex) {
-    const newPickers = [...displayPickers.value]
-    const draggedItem = newPickers.splice(draggedItemIndex, 1)[0]
-    newPickers.splice(index, 0, draggedItem)
-    pickers.value = newPickers.map((p, i) => ({ ...p, order: i + 1 }))
-    draggedItemIndex = index
-  }
-}
-
-function onDrop(event: DragEvent) {
-  event.preventDefault()
-  // The actual reordering is handled in onDragOver for immediate visual feedback
-  // We just need to reset the draggedItemIndex here
-  draggedItemIndex = -1
-}
-
 </script>
 
 <template>
@@ -140,13 +99,9 @@ function onDrop(event: DragEvent) {
     </div>
     <ul>
       <li
-        v-for="(picker, index) in displayPickers"
+        v-for="picker in displayPickers"
         :key="picker.uuid"
         class="bg-slate-800 p-4 rounded-lg mb-2 flex flex-col gap-2"
-        draggable="true"
-        @dragstart="onDragStart($event, index)"
-        @dragover.prevent="onDragOver($event, index)"
-        @drop.prevent="onDrop($event)"
       >
         <div class="flex flex-col gap-1">
           <label :for="`name-${picker.uuid}`" class="text-sm text-slate-300">Name</label>
@@ -176,31 +131,6 @@ function onDrop(event: DragEvent) {
       </li>
     </ul>
   </div>
-
-  <MenuModal
-    v-if="showReorderModal"
-    title="Reorder Pickers"
-    @close="closeReorderModal"
-    :draggable="true"
-  >
-    <template v-slot="{ dragStart, dragOver, drop }">
-      <div
-        v-for="(picker, index) in displayPickers"
-        :key="picker.uuid"
-        class="p-3 bg-slate-700 rounded-md cursor-grab flex justify-between items-center"
-        draggable="true"
-        @dragstart="dragStart($event, index)"
-        @dragover.prevent="dragOver($event, index)"
-        @drop.prevent="drop($event, index)"
-      >
-        <span>{{ picker.name }}</span>
-        <Icon icon="system-uicons:drag" class="text-slate-300" />
-      </div>
-    </template>
-    <template v-slot:footer>
-      <ActionButton text="Save Order" color="green" @click="saveReorder(displayPickers)" />
-    </template>
-  </MenuModal>
 </template>
 
 <style scoped>

--- a/app/src/views/ManagePickersView.vue
+++ b/app/src/views/ManagePickersView.vue
@@ -132,7 +132,6 @@ async function handleDeletePicker(pickerUuid: string) {
           />
         </div>
         <div class="flex flex-row gap-1">
-          <span>{{ picker.order }}, {{ displayPickers.length }}</span>
           <ActionButton
             text="Down"
             icon="system-uicons:chevron-down"
@@ -158,7 +157,3 @@ async function handleDeletePicker(pickerUuid: string) {
     </ul>
   </div>
 </template>
-
-<style scoped>
-/* Add any specific styles here if needed */
-</style>


### PR DESCRIPTION
Finishes #17 

I was going to implement drag-and-drop reorder, but that didn't really work so well. Maybe I can try again later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Up" and "Down" buttons to reorder pickers directly in the picker management view.
  * Disabled state now visually indicated for action buttons.

* **Improvements**
  * Reordering pickers is now done via buttons instead of manual numeric input, making the process more intuitive.
  * Buttons are disabled appropriately at the top and bottom of the list to prevent invalid moves.

* **Style**
  * Disabled action buttons now display reduced opacity for clearer visual feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->